### PR TITLE
Refactor auth token in the SDK to be async

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -32,7 +32,7 @@ export type AuthOptions = {
 export abstract class IAuth {
 	mode = (typeof window === 'undefined' ? 'json' : 'cookie') as AuthMode;
 
-	abstract readonly token: string | null;
+	abstract readonly token: Promise<string | null>;
 	abstract readonly password: PasswordsHandler;
 
 	abstract login(credentials: AuthCredentials): Promise<AuthResult>;

--- a/tests/base/auth.browser.test.ts
+++ b/tests/base/auth.browser.test.ts
@@ -67,10 +67,10 @@ describe('auth (browser)', function () {
 			password: 'password',
 		});
 
-		expect(sdk.auth.token).toBe('some_access_token');
+		expect(await sdk.auth.token).toBe('some_access_token');
 
 		await sdk.auth.logout();
 
-		expect(sdk.auth.token).toBeNull();
+		expect(await sdk.auth.token).toBeNull();
 	});
 });

--- a/tests/base/auth.node.test.ts
+++ b/tests/base/auth.node.test.ts
@@ -67,12 +67,12 @@ describe('auth (node)', function () {
 
 		await loginPromise;
 
-		expect(sdk.auth.token).toBe('auth_token');
+		expect(await sdk.auth.token).toBe('auth_token');
 
 		const logoutPromise = sdk.auth.logout();
 
 		await logoutPromise;
 
-		expect(sdk.auth.token).toBeNull();
+		expect(await sdk.auth.token).toBeNull();
 	});
 });

--- a/tests/base/auth.test.ts
+++ b/tests/base/auth.test.ts
@@ -62,7 +62,7 @@ describe('auth', function () {
 		const sdk = new Directus(url);
 		await sdk.auth.static('token');
 
-		expect(sdk.auth.token);
+		expect(await sdk.auth.token);
 	});
 
 	test(`invalid credentials token should not set the token`, async (url, nock) => {
@@ -90,7 +90,7 @@ describe('auth', function () {
 			//
 		}
 
-		expect(sdk.auth.token).toBeNull();
+		expect(await sdk.auth.token).toBeNull();
 	});
 
 	test(`invalid static token should not set the token`, async (url, nock) => {
@@ -118,6 +118,6 @@ describe('auth', function () {
 			//
 		}
 
-		expect(sdk.auth.token).toBeNull();
+		expect(await sdk.auth.token).toBeNull();
 	});
 });


### PR DESCRIPTION
This PR is breaking change for existing SDK users.
Use `await` when accessing `directus.auth.token`.


Ref https://github.com/directus/directus/pull/14050

Fixes #2 