### PR TITLE
Better query fields autocompletion and query return type based on fields value

### DIFF
--- a/src/base/directus.ts
+++ b/src/base/directus.ts
@@ -207,6 +207,6 @@ export class Directus<T extends TypeMap> implements IDirectus<T> {
 	}
 
 	items<C extends string, I = TypeOf<T, C>>(collection: C): IItems<I> {
-		return this._items[collection] || (this._items[collection] = new ItemsHandler<T>(collection, this.transport));
+		return this._items[collection] || (this._items[collection] = new ItemsHandler<I>(collection, this.transport));
 	}
 }

--- a/src/handlers/singleton.ts
+++ b/src/handlers/singleton.ts
@@ -13,15 +13,15 @@ export class SingletonHandler<T> implements ISingleton<T> {
 		this.endpoint = collection.startsWith('directus_') ? `/${collection.substring(9)}` : `/items/${collection}`;
 	}
 
-	async read(query?: QueryOne<T>): Promise<OneItem<T>> {
-		const item = await this.transport.get<T>(`${this.endpoint}`, {
+	async read<Q extends QueryOne<T>>(query?: Q): Promise<OneItem<T, Q>> {
+		const item = await this.transport.get<OneItem<T, Q>>(`${this.endpoint}`, {
 			params: query,
 		});
 		return item.data;
 	}
 
-	async update(data: PartialItem<T>, _query?: QueryOne<T>): Promise<OneItem<T>> {
-		const item = await this.transport.patch<T>(`${this.endpoint}`, data, {
+	async update<Q extends QueryOne<T>>(data: PartialItem<T>, _query?: Q): Promise<OneItem<T, Q>> {
+		const item = await this.transport.patch<OneItem<T, Q>>(`${this.endpoint}`, data, {
 			params: _query,
 		});
 

--- a/src/items.ts
+++ b/src/items.ts
@@ -127,7 +127,7 @@ type UnionToTuple<TUnion, TResult extends Array<unknown> = []> = TUnion[] extend
 	? TResult
 	: UnionToTuple<Exclude<TUnion, LastUnion<TUnion>>, [...TResult, LastUnion<TUnion>]>;
 
-export type PickedPartialItem<T extends Item, Fields, Val = Record<string, unknown>> = T extends Record<string, never>
+export type PickedPartialItem<T extends Item, Fields, Val = Record<string, unknown>> = T extends unknown
 	? any
 	: Fields extends string[]
 	? Fields['length'] extends 0
@@ -165,8 +165,8 @@ type IntersectionToObject<U> = U extends (infer U2)[]
 		  }
 	: never;
 
-export type QueryOne<T = Record<string, never>> = {
-	fields?: T extends Record<string, never> ? string | string[] : DotSeparated<T, 5> | DotSeparated<T, 5>[];
+export type QueryOne<T = unknown> = {
+	fields?: T extends unknown ? string | string[] : DotSeparated<T, 5> | DotSeparated<T, 5>[];
 	search?: string;
 	deep?: Deep<T>;
 	export?: 'json' | 'csv' | 'xml';

--- a/src/items.ts
+++ b/src/items.ts
@@ -251,12 +251,12 @@ type AppendToPath<Path extends string, Appendix extends string> = Path extends '
 type OneLevelUp<Path extends string> = Path extends `${infer Start}.${infer Middle}.${infer Rest}`
 	? Rest extends `${string}.${string}.${string}`
 		? `${Start}.${Middle}.${OneLevelUp<Rest>}`
-		: Rest extends `${infer NewMiddle}.${infer _}`
+		: Rest extends `${infer NewMiddle}.${string}`
 		? `${Start}.${Middle}.${NewMiddle}`
 		: Rest extends string
 		? `${Start}.${Middle}`
 		: ''
-	: Path extends `${infer Start}.${infer _}`
+	: Path extends `${infer Start}.${string}`
 	? Start
 	: '';
 
@@ -281,11 +281,15 @@ type DefaultAppends<Path extends string, Appendix extends string, Nested extends
 				| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, '*'>, '*'>
 				| AppendToPath<AppendToPath<Path, Appendix>, '*'>
 				| AppendToPath<Path, '*'>
+				| AppendToPath<AppendToPath<Path, '*'>, '*'>
 		:
+				| AppendToPath<AppendToPath<AppendToPath<LevelsToAsterisks<OneLevelUp<Path>>, Path>, Appendix>, '*'>
 				| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, Appendix>, '*'>
 				| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, '*'>, '*'>
 				| AppendToPath<AppendToPath<Path, Appendix>, '*'>
+				| AppendToPath<AppendToPath<Path, '*'>, '*'>
 				| AppendToPath<Path, '*'>
+				// Unique to this branch
 				| AppendToPath<AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>, '*'>
 				| AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>
 	: AppendToPath<Path, Appendix> | AppendToPath<LevelsToAsterisks<Path>, Appendix>;

--- a/src/items.ts
+++ b/src/items.ts
@@ -112,14 +112,8 @@ type ArrayTreeBranch<U, Path extends string, Val = Record<string, never>, NU = N
 	: DeepPathToObject<Path, NU, Val>;
 
 type TreeLeaf<T, NT = NonNullable<T>> = NT extends (infer U)[]
-	? (Extract<NonNullable<U>, Record<string, any>> extends Record<string, any>
-			? Exclude<NonNullable<U>, Record<string, any>>
-			: NonNullable<U>)[]
-	: Extract<NT, Record<string, any>> extends Record<string, any>
-	? Exclude<NT, Record<string, any>>
-	: NT extends Record<string, any>
-	? undefined
-	: NT;
+	? Exclude<NonNullable<U>, Record<string, unknown>>[]
+	: Exclude<NT, Record<string, unknown>>;
 
 type UnionToIntersectionFn<TUnion> = (TUnion extends TUnion ? (union: () => TUnion) => void : never) extends (
 	intersection: infer Intersection

--- a/src/items.ts
+++ b/src/items.ts
@@ -280,10 +280,9 @@ type DefaultAppends<Path extends string, Appendix extends string, Nested extends
 				| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, Appendix>, '*'>
 				| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, '*'>, '*'>
 				| AppendToPath<AppendToPath<Path, Appendix>, '*'>
-				| AppendToPath<Path, '*'>
 				| AppendToPath<AppendToPath<Path, '*'>, '*'>
+				| AppendToPath<Path, '*'>
 		:
-				| AppendToPath<AppendToPath<AppendToPath<LevelsToAsterisks<OneLevelUp<Path>>, Path>, Appendix>, '*'>
 				| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, Appendix>, '*'>
 				| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, '*'>, '*'>
 				| AppendToPath<AppendToPath<Path, Appendix>, '*'>
@@ -291,6 +290,8 @@ type DefaultAppends<Path extends string, Appendix extends string, Nested extends
 				| AppendToPath<Path, '*'>
 				// Unique to this branch
 				| AppendToPath<AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>, '*'>
+				| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, Appendix>, '*'>
+				| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, '*'>, '*'>
 				| AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>
 	: AppendToPath<Path, Appendix> | AppendToPath<LevelsToAsterisks<Path>, Appendix>;
 

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -4,6 +4,6 @@ import { Item, OneItem, PartialItem, QueryOne } from './items';
  * CRUD at its finest
  */
 export interface ISingleton<T extends Item> {
-	read(query?: QueryOne<T>): Promise<OneItem<T>>;
-	update(item: PartialItem<T>, query?: QueryOne<T>): Promise<OneItem<T>>;
+	read<Q extends QueryOne<T>>(query?: Q): Promise<OneItem<T, Q>>;
+	update<Q extends QueryOne<T>>(item: PartialItem<T>, query?: Q): Promise<OneItem<T, Q>>;
 }

--- a/tests/blog.d.ts
+++ b/tests/blog.d.ts
@@ -5,6 +5,7 @@ export type Post = {
 	title: string;
 	body: string;
 	published: boolean;
+	author: ID | Author;
 };
 
 export type Category = {
@@ -12,7 +13,14 @@ export type Category = {
 	name: string;
 };
 
+export type Author = {
+	id: ID;
+	name: string;
+	posts: (ID | Post)[];
+};
+
 export type Blog = {
 	posts: Post;
 	categories: Category;
+	author: Author;
 };

--- a/tests/items.test.ts
+++ b/tests/items.test.ts
@@ -137,11 +137,11 @@ describe('items', function () {
 
 		expect(items.data?.[0]?.id).toBe(1);
 		expect(items.data?.[0]?.title).toBe(`My first post`);
-		expect(items.data?.[0]?.body).toBeUndefined();
+		expect((<any>items.data?.[0])?.body).toBeUndefined();
 
 		expect(items.data?.[1]?.id).toBe(2);
 		expect(items.data?.[1]?.title).toBe(`My second post`);
-		expect(items.data?.[1]?.body).toBeUndefined();
+		expect((<any>items.data?.[1])?.body).toBeUndefined();
 	});
 
 	test(`create one item`, async (url, nock) => {


### PR DESCRIPTION
I've implemented better autocompletion for the fields option in a query, as it now shows nested object values. The fields you pass in are also used to properly autocomplete the return value of the query.

Further testing is not a luxury at this point, so I'd love to open the discussion and talk about your expectations regarding this.

### Please note

These additions ~_do_~ probably introduce changes to how ambiguous typing is handled. ~_For example: you can only pass "valid" collection names into `.items()` and `.singleton()`._~

## Example

https://user-images.githubusercontent.com/23699599/181059687-66c8e9e2-77bb-4fe8-a7ff-a80269f897ab.mp4

The repository containing the code in the video can be found at [jonahgoldwastaken/directus-sdk-types-showcase](https://github.com/jonahgoldwastaken/directus-sdk-types-showcase).