### PR TITLE
Avoid overriding filter in readMany handler

### DIFF
--- a/src/base/items.ts
+++ b/src/base/items.ts
@@ -40,12 +40,12 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 
 		const { data, meta } = await this.transport.get<OneItem<T, Q>[]>(`${this.endpoint}`, {
 			params: {
+				...query,
 				filter: {
 					[primaryKeyField!.field]: { _in: ids },
 					...query?.filter,
 				},
 				sort: query?.sort || primaryKeyField!.field,
-				...query,
 			},
 			...options?.requestOptions,
 		});


### PR DESCRIPTION
Currently, the readMany method in ItemsHandler is overriding the filter when a query.filter is given from the outside. This ignores the filter `_in` which contains the list of IDs.

With something like: 
```
await directus.items(collection).readMany([id1, id2], {
   filter: { status: { _neq: "archived" } }
}
```
The resultant URL is something like `/items/collection?filter={"status":{"_neq":"archived"}}`, which is not right.

This PR fixes that issue.