### PR TITLE
Fix typing on deep queries

### DIFF
--- a/src/items.ts
+++ b/src/items.ts
@@ -190,6 +190,18 @@ export type Deep<T> = {
 
 export type DeepQueryMany<T> = {
 	[K in keyof QueryMany<SingleItem<T>> as `_${string & K}`]: QueryMany<SingleItem<T>>[K];
+} & {
+	[K in keyof NestedObjectKeys<SingleItem<T>>]?: DeepQueryMany<NestedObjectKeys<SingleItem<T>>[K]>;
+};
+
+export type NestedObjectKeys<T> = {
+	[P in keyof T]: NonNullable<T[P]> extends (infer U)[]
+		? Extract<U, Record<string, unknown>> extends Record<string, unknown>
+			? Extract<U, Record<string, unknown>>
+			: never
+		: Extract<NonNullable<T[P]>, Record<string, unknown>> extends Record<string, unknown>
+		? Extract<NonNullable<T[P]>, Record<string, unknown>>
+		: never;
 };
 
 export type SharedAggregate = {
@@ -251,7 +263,7 @@ export type ItemsOptions = {
 };
 
 type SingleItem<T> = Exclude<Single<T>, ID>;
-type Single<T> = T extends Array<unknown> ? T[number] : T;
+type Single<T, NT = NonNullable<T>> = NT extends Array<unknown> ? NT[number] : NT;
 
 /**
  * CRUD at its finest


### PR DESCRIPTION
When passing `deep` parameters into a query, TypeScript errors would occur with the example below:
```typescript
const data = await directus('products').readByQuery({
  fields: ['variants.translations.name', 'variants.translations.slug'],
  deep: {
    variants: {
      translations: { // This used to throw a TS error as only '_filter', '_sort' etc. was allowed inside 'variants'.
        _filter: {
          languages_code: {
            _eq: 'nl-NL'
          }
        }
      }
    }
  }
})
```
Nesting object properties before using one of the global parameters now doesn't throw an error anymore, and is properly typed. The only exception is that it throws an error with M2A queries, as they aren't caught at all at the moment.