### PR TITLE
Don't modify the return type on a read query without specified fields

### DIFF
--- a/src/base/items.ts
+++ b/src/base/items.ts
@@ -6,7 +6,7 @@ import {
 	QueryMany,
 	OneItem,
 	ManyItems,
-	PartialItem,
+	ItemInput,
 	ItemsOptions,
 	EmptyParamError,
 } from '../items';
@@ -69,7 +69,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 	}
 
 	async createOne<Q extends QueryOne<T>>(
-		item: PartialItem<T>,
+		item: ItemInput<T>,
 		query?: Q,
 		options?: ItemsOptions
 	): Promise<OneItem<T, Q>> {
@@ -82,7 +82,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 	}
 
 	async createMany<Q extends QueryMany<T>>(
-		items: PartialItem<T>[],
+		items: ItemInput<T>[],
 		query?: Q,
 		options?: ItemsOptions
 	): Promise<ManyItems<T, Q>> {
@@ -94,7 +94,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 
 	async updateOne<Q extends QueryOne<T>>(
 		id: ID,
-		item: PartialItem<T>,
+		item: ItemInput<T>,
 		query?: Q,
 		options?: ItemsOptions
 	): Promise<OneItem<T, Q>> {
@@ -109,7 +109,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 
 	async updateMany<Q extends QueryMany<T>>(
 		ids: ID[],
-		data: PartialItem<T>,
+		data: ItemInput<T>,
 		query?: Q,
 		options?: ItemsOptions
 	): Promise<ManyItems<T, Q>> {
@@ -128,7 +128,7 @@ export class ItemsHandler<T extends Item> implements IItems<T> {
 
 	async updateByQuery<Q extends QueryMany<T>>(
 		updateQuery: QueryMany<T>,
-		data: PartialItem<T>,
+		data: ItemInput<T>,
 		query?: Q,
 		options?: ItemsOptions
 	): Promise<ManyItems<T, Q>> {

--- a/src/handlers/collections.ts
+++ b/src/handlers/collections.ts
@@ -2,7 +2,7 @@
  * Collections handler
  */
 
-import { ManyItems, OneItem, PartialItem, QueryOne, EmptyParamError } from '../items';
+import { ManyItems, OneItem, ItemInput, QueryOne, EmptyParamError } from '../items';
 import { ITransport } from '../transport';
 import { CollectionType, DefaultType } from '../types';
 
@@ -17,7 +17,7 @@ export class CollectionsHandler<T = CollectionItem> {
 	async readOne(collection: string): Promise<OneItem<T>> {
 		if (`${collection}` === '') throw new EmptyParamError('collection');
 		const response = await this.transport.get(`/collections/${collection}`);
-		return response.data as T;
+		return response.data as OneItem<T>;
 	}
 
 	async readAll(): Promise<ManyItems<T>> {
@@ -29,11 +29,11 @@ export class CollectionsHandler<T = CollectionItem> {
 		};
 	}
 
-	async createOne(collection: PartialItem<T>): Promise<OneItem<T>> {
-		return (await this.transport.post<T>(`/collections`, collection)).data;
+	async createOne(collection: ItemInput<T>): Promise<OneItem<T>> {
+		return (await this.transport.post<OneItem<T>>(`/collections`, collection)).data;
 	}
 
-	async createMany(collections: PartialItem<T>[]): Promise<ManyItems<T>> {
+	async createMany(collections: ItemInput<T>[]): Promise<ManyItems<T>> {
 		const { data, meta } = await this.transport.post(`/collections`, collections);
 
 		return {
@@ -42,10 +42,10 @@ export class CollectionsHandler<T = CollectionItem> {
 		};
 	}
 
-	async updateOne(collection: string, item: PartialItem<T>, query?: QueryOne<T>): Promise<OneItem<T>> {
+	async updateOne(collection: string, item: ItemInput<T>, query?: QueryOne<T>): Promise<OneItem<T>> {
 		if (`${collection}` === '') throw new EmptyParamError('collection');
 		return (
-			await this.transport.patch<PartialItem<T>>(`/collections/${collection}`, item, {
+			await this.transport.patch<OneItem<T>>(`/collections/${collection}`, item, {
 				params: query,
 			})
 		).data;

--- a/src/handlers/fields.ts
+++ b/src/handlers/fields.ts
@@ -2,7 +2,7 @@
  * Fields handler
  */
 
-import { ManyItems, OneItem, PartialItem, EmptyParamError } from '../items';
+import { ManyItems, OneItem, ItemInput, EmptyParamError, DefaultItem } from '../items';
 import { ITransport } from '../transport';
 import { FieldType, DefaultType, ID } from '../types';
 
@@ -18,7 +18,7 @@ export class FieldsHandler<T = FieldItem> {
 		if (`${collection}` === '') throw new EmptyParamError('collection');
 		if (`${id}` === '') throw new EmptyParamError('id');
 		const response = await this.transport.get(`/fields/${collection}/${id}`);
-		return response.data as T;
+		return response.data as OneItem<T>;
 	}
 
 	async readMany(collection: string): Promise<ManyItems<T>> {
@@ -32,15 +32,15 @@ export class FieldsHandler<T = FieldItem> {
 		return response.data as T;
 	}
 
-	async createOne(collection: string, item: PartialItem<T>): Promise<OneItem<T>> {
+	async createOne(collection: string, item: ItemInput<T>): Promise<OneItem<T>> {
 		if (`${collection}` === '') throw new EmptyParamError('collection');
-		return (await this.transport.post<T>(`/fields/${collection}`, item)).data;
+		return (await this.transport.post<DefaultItem<T>>(`/fields/${collection}`, item)).data;
 	}
 
-	async updateOne(collection: string, field: string, item: PartialItem<T>): Promise<OneItem<T>> {
+	async updateOne(collection: string, field: string, item: ItemInput<T>): Promise<OneItem<T>> {
 		if (`${collection}` === '') throw new EmptyParamError('collection');
 		if (`${field}` === '') throw new EmptyParamError('field');
-		return (await this.transport.patch<PartialItem<T>>(`/fields/${collection}/${field}`, item)).data;
+		return (await this.transport.patch<DefaultItem<T>>(`/fields/${collection}/${field}`, item)).data;
 	}
 
 	async deleteOne(collection: string, field: string): Promise<void> {

--- a/src/handlers/files.ts
+++ b/src/handlers/files.ts
@@ -3,7 +3,7 @@
  */
 
 import { ItemsHandler } from '../base/items';
-import { OneItem, PartialItem } from '../items';
+import { OneItem, ItemInput } from '../items';
 import { ITransport } from '../transport';
 import { FileType, DefaultType } from '../types';
 
@@ -14,8 +14,8 @@ export class FilesHandler<T = DefaultType> extends ItemsHandler<FileItem<T>> {
 		super('directus_files', transport);
 	}
 
-	async import(body: { url: string; data?: PartialItem<T> }): Promise<OneItem<T>> {
+	async import(body: { url: string; data?: ItemInput<T> }): Promise<OneItem<T>> {
 		const response = await this.transport.post(`/files/import`, body);
-		return response.data as T;
+		return response.data as OneItem<T>;
 	}
 }

--- a/src/handlers/me.ts
+++ b/src/handlers/me.ts
@@ -1,4 +1,4 @@
-import { PartialItem, QueryOne } from '../items';
+import { ItemInput, QueryOne } from '../items';
 import { ITransport } from '../transport';
 import { TFAHandler } from './tfa';
 
@@ -14,14 +14,14 @@ export class MeHandler<T> {
 		return this._tfa || (this._tfa = new TFAHandler(this._transport));
 	}
 
-	async read(query?: QueryOne<T>): Promise<PartialItem<T>> {
+	async read(query?: QueryOne<T>): Promise<ItemInput<T>> {
 		const response = await this._transport.get<T>('/users/me', {
 			params: query,
 		});
 		return response.data!;
 	}
 
-	async update(data: PartialItem<T>, query?: QueryOne<T>): Promise<PartialItem<T>> {
+	async update(data: ItemInput<T>, query?: QueryOne<T>): Promise<ItemInput<T>> {
 		const response = await this._transport.patch<T>(`/users/me`, data, {
 			params: query,
 		});

--- a/src/handlers/relations.ts
+++ b/src/handlers/relations.ts
@@ -1,7 +1,7 @@
 /**
  * Relations handler
  */
-import { ManyItems, OneItem, PartialItem, EmptyParamError } from '../items';
+import { ManyItems, OneItem, ItemInput, EmptyParamError } from '../items';
 import { ITransport } from '../transport';
 import { RelationType, DefaultType, ID } from '../types';
 
@@ -17,7 +17,7 @@ export class RelationsHandler<T = RelationItem> {
 		if (`${collection}` === '') throw new EmptyParamError('collection');
 		if (`${id}` === '') throw new EmptyParamError('id');
 		const response = await this.transport.get(`/relations/${collection}/${id}`);
-		return response.data as T;
+		return response.data as OneItem<T>;
 	}
 
 	async readMany(collection: string): Promise<ManyItems<T>> {
@@ -31,14 +31,14 @@ export class RelationsHandler<T = RelationItem> {
 		return response.data;
 	}
 
-	async createOne(item: PartialItem<T>): Promise<OneItem<T>> {
-		return (await this.transport.post<T>(`/relations`, item)).data;
+	async createOne(item: ItemInput<T>): Promise<OneItem<T>> {
+		return (await this.transport.post<OneItem<T>>(`/relations`, item)).data;
 	}
 
-	async updateOne(collection: string, field: string, item: PartialItem<T>): Promise<OneItem<T>> {
+	async updateOne(collection: string, field: string, item: ItemInput<T>): Promise<OneItem<T>> {
 		if (`${collection}` === '') throw new EmptyParamError('collection');
 		if (`${field}` === '') throw new EmptyParamError('field');
-		return (await this.transport.patch<PartialItem<T>>(`/relations/${collection}/${field}`, item)).data;
+		return (await this.transport.patch<OneItem<T>>(`/relations/${collection}/${field}`, item)).data;
 	}
 
 	async deleteOne(collection: string, field: string): Promise<void> {

--- a/src/handlers/singleton.ts
+++ b/src/handlers/singleton.ts
@@ -1,5 +1,5 @@
 import { ITransport } from '../transport';
-import { QueryOne, OneItem, PartialItem } from '../items';
+import { QueryOne, OneItem, ItemInput } from '../items';
 import { ISingleton } from '../singleton';
 
 export class SingletonHandler<T> implements ISingleton<T> {
@@ -20,7 +20,7 @@ export class SingletonHandler<T> implements ISingleton<T> {
 		return item.data;
 	}
 
-	async update<Q extends QueryOne<T>>(data: PartialItem<T>, _query?: Q): Promise<OneItem<T, Q>> {
+	async update<Q extends QueryOne<T>>(data: ItemInput<T>, _query?: Q): Promise<OneItem<T, Q>> {
 		const item = await this.transport.patch<OneItem<T, Q>>(`${this.endpoint}`, data, {
 			params: _query,
 		});

--- a/src/items.ts
+++ b/src/items.ts
@@ -5,17 +5,17 @@ export type Field = string;
 
 export type Item = Record<string, any>;
 
-export type PartialItem<T> = {
-	[P in keyof T]?: T[P] extends Record<string, any> ? PartialItem<T[P]> : T[P];
-};
-
 export type InferQueryType<T extends ManyItems<any> | QueryOne<any>> = 'data' extends keyof T ? T['data'] : T;
+
+type DefaultItem<T extends Record<string, unknown>> = {
+	[K in keyof T]: T[K] extends (infer _)[] ? (string | number)[] : T[K];
+};
 
 export type OneItem<
 	T extends Item,
-	Q extends QueryOne<T> = Record<string, any>,
+	Q extends QueryOne<T> = Record<'fields', undefined>,
 	F extends string[] | false = QueryFields<Q>
-> = (F extends false ? PartialItem<T> : PickedPartialItem<T, F>) | null | undefined;
+> = (F extends false ? DefaultItem<T> : PickedPartialItem<T, F>) | null | undefined;
 
 export type ManyItems<T extends Item, Q extends QueryMany<T> = Record<string, any>> = {
 	data?: OneItem<T, Q>[] | null;
@@ -34,7 +34,7 @@ export enum Meta {
 	FILTER_COUNT = 'filter_count',
 }
 
-export type QueryFields<Q extends Record<string, any>> = Q extends Record<'fields', any>
+export type QueryFields<Q extends Record<string, any>> = Q extends Record<'fields', unknown>
 	? Q['fields'] extends string
 		? [Q['fields']]
 		: Q['fields'] extends string[]

--- a/src/items.ts
+++ b/src/items.ts
@@ -12,7 +12,9 @@ type DefaultItem<T extends Record<string, unknown>> = {
 		? Extract<NonNullable<U>, Record<string, unknown>> extends never
 			? U[]
 			: (string | number)[]
-		: T[K];
+		: Extract<T[K], Record<string, unknown>> extends never
+		? T[K]
+		: Exclude<T[K], Record<string, unknown>> | string | number;
 };
 
 export type OneItem<

--- a/src/items.ts
+++ b/src/items.ts
@@ -12,19 +12,19 @@ export type InferQueryType<T extends ManyItems<any> | QueryOne<any>> = 'data' ex
 
 export type DefaultItem<T> = {
 	[K in keyof T]: NonNullable<T[K]> extends (infer U)[]
-	? Extract<NonNullable<U>, Record<string, unknown>> extends never
-	? U[]
-	: (string | number)[]
-	: Extract<T[K], Record<string, unknown>> extends never
-	? T[K]
-	: Exclude<T[K], Record<string, unknown>> | string | number;
+		? Extract<NonNullable<U>, Record<string, unknown>> extends never
+			? U[]
+			: (string | number)[]
+		: Extract<T[K], Record<string, unknown>> extends never
+		? T[K]
+		: Exclude<T[K], Record<string, unknown>> | string | number;
 };
 
 export type OneItem<
 	T extends Item,
 	Q extends QueryOne<T> = Record<'fields', undefined>,
 	F extends string[] | false = QueryFields<Q>
-	> = (F extends false ? DefaultItem<T> : PickedDefaultItem<T, F>) | null | undefined;
+> = (F extends false ? DefaultItem<T> : PickedDefaultItem<T, F>) | null | undefined;
 
 export type ManyItems<T extends Item, Q extends QueryMany<T> = Record<string, any>> = {
 	data?: OneItem<T, Q>[] | null;
@@ -45,10 +45,10 @@ export enum Meta {
 
 export type QueryFields<Q extends Record<string, any>> = Q extends Record<'fields', unknown>
 	? Q['fields'] extends string
-	? [Q['fields']]
-	: Q['fields'] extends string[]
-	? Q['fields']
-	: false
+		? [Q['fields']]
+		: Q['fields'] extends string[]
+		? Q['fields']
+		: false
 	: false;
 
 type DeepPathBranchHelper<T, K extends keyof T, V, R extends string> = K extends keyof V
@@ -61,8 +61,8 @@ type WildCardHelper<T, K extends keyof T, V, R extends string> = string extends 
 	? { [K: string]: T[K] }
 	: NonNullable<T[K]> extends (infer U)[]
 	? Extract<NonNullable<U>, Record<string, unknown>> extends never
-	? TreeLeaf<U>
-	: DeepPathBranchHelper<T, K, V, R>
+		? TreeLeaf<U>
+		: DeepPathBranchHelper<T, K, V, R>
 	: Extract<NonNullable<T[K]>, Record<string, unknown>> extends never
 	? TreeLeaf<T[K]>
 	: DeepPathBranchHelper<T, K, V, R>;
@@ -71,40 +71,40 @@ type DeepPathToObject<
 	Path extends string,
 	T extends Record<string, any>,
 	Val = Record<string, never>
-	> = string extends Path
+> = string extends Path
 	? never
 	: Path extends `${infer Key}.${infer Rest}`
 	? Key extends '*'
-	? Rest extends `${infer NextVal}.${string}`
-	? NextVal extends '*'
-	? Val & {
-		[K in keyof T]: WildCardHelper<T, K, Val, Rest>;
-	}
-	: Val & {
-		[K in keyof T]?: NextVal extends keyof T[K] ? DeepPathBranchHelper<T, K, Val, Rest> : never;
-	}
-	: Rest extends '*'
-	? Val & {
-		[K in keyof T]: WildCardHelper<T, K, Val, Rest>;
-	}
-	: Val & {
-		[K in keyof T]?: Rest extends keyof T[K] ? DeepPathBranchHelper<T, K, Val, Rest> : never;
-	}
-	: Key extends keyof T
-	? Val & {
-		[_ in Key]?: DeepPathBranchHelper<T, Key, Val, Rest>;
-	}
-	: never
+		? Rest extends `${infer NextVal}.${string}`
+			? NextVal extends '*'
+				? Val & {
+						[K in keyof T]: WildCardHelper<T, K, Val, Rest>;
+				  }
+				: Val & {
+						[K in keyof T]?: NextVal extends keyof T[K] ? DeepPathBranchHelper<T, K, Val, Rest> : never;
+				  }
+			: Rest extends '*'
+			? Val & {
+					[K in keyof T]: WildCardHelper<T, K, Val, Rest>;
+			  }
+			: Val & {
+					[K in keyof T]?: Rest extends keyof T[K] ? DeepPathBranchHelper<T, K, Val, Rest> : never;
+			  }
+		: Key extends keyof T
+		? Val & {
+				[_ in Key]?: DeepPathBranchHelper<T, Key, Val, Rest>;
+		  }
+		: never
 	: string extends keyof T
 	? Val & Record<string, unknown>
 	: Path extends keyof T
 	? Val & {
-		[K in Path]?: TreeLeaf<T[K]>;
-	}
+			[K in Path]?: TreeLeaf<T[K]>;
+	  }
 	: Path extends '*'
 	? Val & {
-		[K in keyof T]?: TreeLeaf<T[K]>;
-	}
+			[K in keyof T]?: TreeLeaf<T[K]>;
+	  }
 	: never;
 
 type TreeBranch<T, Path extends string, Val = Record<string, never>, NT = NonNullable<T>> = NT extends (infer U)[]
@@ -118,8 +118,8 @@ type ArrayTreeBranch<U, Path extends string, Val = Record<string, never>, NU = N
 	Record<string, unknown>
 > extends infer OB
 	? Val extends (infer _)[]
-	? DeepPathToObject<Path, OB, Val[number]>
-	: DeepPathToObject<Path, OB, Val>
+		? DeepPathToObject<Path, OB, Val[number]>
+		: DeepPathToObject<Path, OB, Val>
 	: Val extends (infer _)[]
 	? DeepPathToObject<Path, NU, Val[number]>
 	: DeepPathToObject<Path, NU, Val>;
@@ -144,38 +144,38 @@ export type PickedDefaultItem<T extends Item, Fields, Val = Record<string, unkno
 	? any
 	: Fields extends string[]
 	? Fields['length'] extends 0
-	? T
-	: UnionToTuple<Fields[number]> extends [infer First, ...infer Rest]
-	? First extends string
-	? IntersectionToObject<
-		Rest['length'] extends 0
-		? DeepPathToObject<First, T, Val>
-		: PickedDefaultItem<T, Rest, DeepPathToObject<First, T, Val>>
-	>
-	: never
-	: never
+		? T
+		: UnionToTuple<Fields[number]> extends [infer First, ...infer Rest]
+		? First extends string
+			? IntersectionToObject<
+					Rest['length'] extends 0
+						? DeepPathToObject<First, T, Val>
+						: PickedDefaultItem<T, Rest, DeepPathToObject<First, T, Val>>
+			  >
+			: never
+		: never
 	: never;
 
 type IntersectionToObject<U> = U extends (infer U2)[]
 	? Array<IntersectionToObject<U2>>
 	: U extends infer O
 	? O extends string
-	? string
-	: O extends number
-	? number
-	: O extends symbol
-	? symbol
-	: O extends boolean
-	? boolean
-	: {
-		[K in keyof O as unknown extends O[K] ? never : K]: O[K] extends (infer U)[]
-		? Array<IntersectionToObject<U>>
-		: IsUnion<O[K]> extends true
-		? IntersectionToObject<O[K]>
-		: O[K] extends Record<string, any>
-		? IntersectionToObject<O[K]>
-		: O[K];
-	}
+		? string
+		: O extends number
+		? number
+		: O extends symbol
+		? symbol
+		: O extends boolean
+		? boolean
+		: {
+				[K in keyof O as unknown extends O[K] ? never : K]: O[K] extends (infer U)[]
+					? Array<IntersectionToObject<U>>
+					: IsUnion<O[K]> extends true
+					? IntersectionToObject<O[K]>
+					: O[K] extends Record<string, any>
+					? IntersectionToObject<O[K]>
+					: O[K];
+		  }
 	: never;
 
 export type QueryOne<T = unknown> = {
@@ -204,17 +204,17 @@ export type Deep<T> = {
 export type DeepQueryMany<T> = {
 	[K in keyof QueryMany<SingleItem<T>> as `_${string & K}`]: QueryMany<SingleItem<T>>[K];
 } & {
-		[K in keyof NestedObjectKeys<SingleItem<T>>]?: DeepQueryMany<NestedObjectKeys<SingleItem<T>>[K]>;
-	};
+	[K in keyof NestedObjectKeys<SingleItem<T>>]?: DeepQueryMany<NestedObjectKeys<SingleItem<T>>[K]>;
+};
 
 export type NestedObjectKeys<T> = {
 	[P in keyof T]: NonNullable<T[P]> extends (infer U)[]
-	? Extract<U, Record<string, unknown>> extends Record<string, unknown>
-	? Extract<U, Record<string, unknown>>
-	: never
-	: Extract<NonNullable<T[P]>, Record<string, unknown>> extends Record<string, unknown>
-	? Extract<NonNullable<T[P]>, Record<string, unknown>>
-	: never;
+		? Extract<U, Record<string, unknown>> extends Record<string, unknown>
+			? Extract<U, Record<string, unknown>>
+			: never
+		: Extract<NonNullable<T[P]>, Record<string, unknown>> extends Record<string, unknown>
+		? Extract<NonNullable<T[P]>, Record<string, unknown>>
+		: never;
 };
 
 export type SharedAggregate = {
@@ -316,24 +316,24 @@ type IsUnion<T, U extends T = T> = T extends unknown ? ([U] extends [T] ? false 
 type AppendToPath<Path extends string, Appendix extends string> = Path extends '' ? Appendix : `${Path}.${Appendix}`;
 type OneLevelUp<Path extends string> = Path extends `${infer Start}.${infer Middle}.${infer Rest}`
 	? Rest extends `${string}.${string}.${string}`
-	? `${Start}.${Middle}.${OneLevelUp<Rest>}`
-	: Rest extends `${infer NewMiddle}.${string}`
-	? `${Start}.${Middle}.${NewMiddle}`
-	: Rest extends string
-	? `${Start}.${Middle}`
-	: ''
+		? `${Start}.${Middle}.${OneLevelUp<Rest>}`
+		: Rest extends `${infer NewMiddle}.${string}`
+		? `${Start}.${Middle}.${NewMiddle}`
+		: Rest extends string
+		? `${Start}.${Middle}`
+		: ''
 	: Path extends `${infer Start}.${string}`
 	? Start
 	: '';
 
 type LevelsToAsterisks<Path extends string> = Path extends `${string}.${string}.${infer Rest}`
 	? Rest extends `${string}.${string}.${string}`
-	? `*.*.${LevelsToAsterisks<Rest>}`
-	: Rest extends `${string}.${string}`
-	? `*.*.*.*`
-	: Rest extends string
-	? `*.*.*`
-	: ''
+		? `*.*.${LevelsToAsterisks<Rest>}`
+		: Rest extends `${string}.${string}`
+		? `*.*.*.*`
+		: Rest extends string
+		? `*.*.*`
+		: ''
 	: Path extends `${string}.${string}`
 	? '*.*'
 	: Path extends ''
@@ -345,51 +345,51 @@ type DefaultAppends<
 	Appendix extends string,
 	Nested extends boolean = true,
 	Prepend extends boolean = true
-	> =
+> =
 	| AppendToPath<Path, Appendix>
 	| AppendToPath<LevelsToAsterisks<Path>, Appendix>
 	| (Prepend extends true
-		?
-		| AppendToPath<Path, '*'>
-		| AppendToPath<LevelsToAsterisks<Path>, Appendix>
-		| (OneLevelUp<Path> extends '' ? never : AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>)
-		: never)
+			?
+					| AppendToPath<Path, '*'>
+					| AppendToPath<LevelsToAsterisks<Path>, Appendix>
+					| (OneLevelUp<Path> extends '' ? never : AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>)
+			: never)
 	| (Nested extends true
-		?
-		| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, Appendix>, '*'>
-		| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, '*'>, '*'>
-		| AppendToPath<AppendToPath<Path, Appendix>, '*'>
-		| AppendToPath<AppendToPath<Path, '*'>, '*'>
-		| (OneLevelUp<Path> extends ''
-			? never
-			: AppendToPath<AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>, '*'>)
-		: never);
+			?
+					| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, Appendix>, '*'>
+					| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, '*'>, '*'>
+					| AppendToPath<AppendToPath<Path, Appendix>, '*'>
+					| AppendToPath<AppendToPath<Path, '*'>, '*'>
+					| (OneLevelUp<Path> extends ''
+							? never
+							: AppendToPath<AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>, '*'>)
+			: never);
 
 type DotSeparated<
 	T,
 	N extends number,
 	Level extends number[] = [],
 	Path extends string = ''
-	> = Level['length'] extends N
+> = Level['length'] extends N
 	? Path
 	: T extends (infer U)[]
 	? Extract<U, Record<string, unknown>> extends Record<string, unknown>
-	? DotSeparated<Extract<U, Record<string, unknown>>, N, Level, Path>
-	: Path
+		? DotSeparated<Extract<U, Record<string, unknown>>, N, Level, Path>
+		: Path
 	: Extract<NonNullable<T>, Record<string, unknown>> extends Record<string, unknown>
 	? {
-		[K in keyof T]: K extends string
-		? NonNullable<T[K]> extends (infer U)[]
-		? Extract<U, Record<string, unknown>> extends never
-		? DefaultAppends<Path, K, false>
-		:
-		| DotSeparated<Extract<U, Record<string, unknown>>, N, [...Level, 0], AppendToPath<Path, K>>
-		| DefaultAppends<Path, K>
-		: Extract<T[K], Record<string, unknown>> extends never
-		? DefaultAppends<Path, K, false>
-		:
-		| DotSeparated<Extract<T[K], Record<string, unknown>>, N, [...Level, 0], AppendToPath<Path, K>>
-		| DefaultAppends<Path, K>
-		: never;
-	}[keyof T]
+			[K in keyof T]: K extends string
+				? NonNullable<T[K]> extends (infer U)[]
+					? Extract<U, Record<string, unknown>> extends never
+						? DefaultAppends<Path, K, false>
+						:
+								| DotSeparated<Extract<U, Record<string, unknown>>, N, [...Level, 0], AppendToPath<Path, K>>
+								| DefaultAppends<Path, K>
+					: Extract<T[K], Record<string, unknown>> extends never
+					? DefaultAppends<Path, K, false>
+					:
+							| DotSeparated<Extract<T[K], Record<string, unknown>>, N, [...Level, 0], AppendToPath<Path, K>>
+							| DefaultAppends<Path, K>
+				: never;
+	  }[keyof T]
 	: never;

--- a/src/items.ts
+++ b/src/items.ts
@@ -5,23 +5,26 @@ export type Field = string;
 
 export type Item = Record<string, any>;
 
+export type ItemInput<T> = {
+	[P in keyof T]?: T[P] extends Record<string, any> ? ItemInput<T[P]> : T[P];
+};
 export type InferQueryType<T extends ManyItems<any> | QueryOne<any>> = 'data' extends keyof T ? T['data'] : T;
 
-type DefaultItem<T extends Record<string, unknown>> = {
+export type DefaultItem<T> = {
 	[K in keyof T]: NonNullable<T[K]> extends (infer U)[]
-		? Extract<NonNullable<U>, Record<string, unknown>> extends never
-			? U[]
-			: (string | number)[]
-		: Extract<T[K], Record<string, unknown>> extends never
-		? T[K]
-		: Exclude<T[K], Record<string, unknown>> | string | number;
+	? Extract<NonNullable<U>, Record<string, unknown>> extends never
+	? U[]
+	: (string | number)[]
+	: Extract<T[K], Record<string, unknown>> extends never
+	? T[K]
+	: Exclude<T[K], Record<string, unknown>> | string | number;
 };
 
 export type OneItem<
 	T extends Item,
 	Q extends QueryOne<T> = Record<'fields', undefined>,
 	F extends string[] | false = QueryFields<Q>
-> = (F extends false ? DefaultItem<T> : PickedPartialItem<T, F>) | null | undefined;
+	> = (F extends false ? DefaultItem<T> : PickedDefaultItem<T, F>) | null | undefined;
 
 export type ManyItems<T extends Item, Q extends QueryMany<T> = Record<string, any>> = {
 	data?: OneItem<T, Q>[] | null;
@@ -42,10 +45,10 @@ export enum Meta {
 
 export type QueryFields<Q extends Record<string, any>> = Q extends Record<'fields', unknown>
 	? Q['fields'] extends string
-		? [Q['fields']]
-		: Q['fields'] extends string[]
-		? Q['fields']
-		: false
+	? [Q['fields']]
+	: Q['fields'] extends string[]
+	? Q['fields']
+	: false
 	: false;
 
 type DeepPathBranchHelper<T, K extends keyof T, V, R extends string> = K extends keyof V
@@ -58,8 +61,8 @@ type WildCardHelper<T, K extends keyof T, V, R extends string> = string extends 
 	? { [K: string]: T[K] }
 	: NonNullable<T[K]> extends (infer U)[]
 	? Extract<NonNullable<U>, Record<string, unknown>> extends never
-		? TreeLeaf<U>
-		: DeepPathBranchHelper<T, K, V, R>
+	? TreeLeaf<U>
+	: DeepPathBranchHelper<T, K, V, R>
 	: Extract<NonNullable<T[K]>, Record<string, unknown>> extends never
 	? TreeLeaf<T[K]>
 	: DeepPathBranchHelper<T, K, V, R>;
@@ -68,40 +71,40 @@ type DeepPathToObject<
 	Path extends string,
 	T extends Record<string, any>,
 	Val = Record<string, never>
-> = string extends Path
+	> = string extends Path
 	? never
 	: Path extends `${infer Key}.${infer Rest}`
 	? Key extends '*'
-		? Rest extends `${infer NextVal}.${string}`
-			? NextVal extends '*'
-				? Val & {
-						[K in keyof T]: WildCardHelper<T, K, Val, Rest>;
-				  }
-				: Val & {
-						[K in keyof T]?: NextVal extends keyof T[K] ? DeepPathBranchHelper<T, K, Val, Rest> : never;
-				  }
-			: Rest extends '*'
-			? Val & {
-					[K in keyof T]: WildCardHelper<T, K, Val, Rest>;
-			  }
-			: Val & {
-					[K in keyof T]?: Rest extends keyof T[K] ? DeepPathBranchHelper<T, K, Val, Rest> : never;
-			  }
-		: Key extends keyof T
-		? Val & {
-				[_ in Key]?: DeepPathBranchHelper<T, Key, Val, Rest>;
-		  }
-		: never
+	? Rest extends `${infer NextVal}.${string}`
+	? NextVal extends '*'
+	? Val & {
+		[K in keyof T]: WildCardHelper<T, K, Val, Rest>;
+	}
+	: Val & {
+		[K in keyof T]?: NextVal extends keyof T[K] ? DeepPathBranchHelper<T, K, Val, Rest> : never;
+	}
+	: Rest extends '*'
+	? Val & {
+		[K in keyof T]: WildCardHelper<T, K, Val, Rest>;
+	}
+	: Val & {
+		[K in keyof T]?: Rest extends keyof T[K] ? DeepPathBranchHelper<T, K, Val, Rest> : never;
+	}
+	: Key extends keyof T
+	? Val & {
+		[_ in Key]?: DeepPathBranchHelper<T, Key, Val, Rest>;
+	}
+	: never
 	: string extends keyof T
 	? Val & Record<string, unknown>
 	: Path extends keyof T
 	? Val & {
-			[K in Path]?: TreeLeaf<T[K]>;
-	  }
+		[K in Path]?: TreeLeaf<T[K]>;
+	}
 	: Path extends '*'
 	? Val & {
-			[K in keyof T]?: TreeLeaf<T[K]>;
-	  }
+		[K in keyof T]?: TreeLeaf<T[K]>;
+	}
 	: never;
 
 type TreeBranch<T, Path extends string, Val = Record<string, never>, NT = NonNullable<T>> = NT extends (infer U)[]
@@ -115,8 +118,8 @@ type ArrayTreeBranch<U, Path extends string, Val = Record<string, never>, NU = N
 	Record<string, unknown>
 > extends infer OB
 	? Val extends (infer _)[]
-		? DeepPathToObject<Path, OB, Val[number]>
-		: DeepPathToObject<Path, OB, Val>
+	? DeepPathToObject<Path, OB, Val[number]>
+	: DeepPathToObject<Path, OB, Val>
 	: Val extends (infer _)[]
 	? DeepPathToObject<Path, NU, Val[number]>
 	: DeepPathToObject<Path, NU, Val>;
@@ -137,42 +140,42 @@ type UnionToTuple<TUnion, TResult extends Array<unknown> = []> = TUnion[] extend
 	? TResult
 	: UnionToTuple<Exclude<TUnion, LastUnion<TUnion>>, [...TResult, LastUnion<TUnion>]>;
 
-export type PickedPartialItem<T extends Item, Fields, Val = Record<string, unknown>> = unknown extends T
+export type PickedDefaultItem<T extends Item, Fields, Val = Record<string, unknown>> = unknown extends T
 	? any
 	: Fields extends string[]
 	? Fields['length'] extends 0
-		? T
-		: UnionToTuple<Fields[number]> extends [infer First, ...infer Rest]
-		? First extends string
-			? IntersectionToObject<
-					Rest['length'] extends 0
-						? DeepPathToObject<First, T, Val>
-						: PickedPartialItem<T, Rest, DeepPathToObject<First, T, Val>>
-			  >
-			: never
-		: never
+	? T
+	: UnionToTuple<Fields[number]> extends [infer First, ...infer Rest]
+	? First extends string
+	? IntersectionToObject<
+		Rest['length'] extends 0
+		? DeepPathToObject<First, T, Val>
+		: PickedDefaultItem<T, Rest, DeepPathToObject<First, T, Val>>
+	>
+	: never
+	: never
 	: never;
 
 type IntersectionToObject<U> = U extends (infer U2)[]
 	? Array<IntersectionToObject<U2>>
 	: U extends infer O
 	? O extends string
-		? string
-		: O extends number
-		? number
-		: O extends symbol
-		? symbol
-		: O extends boolean
-		? boolean
-		: {
-				[K in keyof O as unknown extends O[K] ? never : K]: O[K] extends (infer U)[]
-					? Array<IntersectionToObject<U>>
-					: IsUnion<O[K]> extends true
-					? IntersectionToObject<O[K]>
-					: O[K] extends Record<string, any>
-					? IntersectionToObject<O[K]>
-					: O[K];
-		  }
+	? string
+	: O extends number
+	? number
+	: O extends symbol
+	? symbol
+	: O extends boolean
+	? boolean
+	: {
+		[K in keyof O as unknown extends O[K] ? never : K]: O[K] extends (infer U)[]
+		? Array<IntersectionToObject<U>>
+		: IsUnion<O[K]> extends true
+		? IntersectionToObject<O[K]>
+		: O[K] extends Record<string, any>
+		? IntersectionToObject<O[K]>
+		: O[K];
+	}
 	: never;
 
 export type QueryOne<T = unknown> = {
@@ -201,17 +204,17 @@ export type Deep<T> = {
 export type DeepQueryMany<T> = {
 	[K in keyof QueryMany<SingleItem<T>> as `_${string & K}`]: QueryMany<SingleItem<T>>[K];
 } & {
-	[K in keyof NestedObjectKeys<SingleItem<T>>]?: DeepQueryMany<NestedObjectKeys<SingleItem<T>>[K]>;
-};
+		[K in keyof NestedObjectKeys<SingleItem<T>>]?: DeepQueryMany<NestedObjectKeys<SingleItem<T>>[K]>;
+	};
 
 export type NestedObjectKeys<T> = {
 	[P in keyof T]: NonNullable<T[P]> extends (infer U)[]
-		? Extract<U, Record<string, unknown>> extends Record<string, unknown>
-			? Extract<U, Record<string, unknown>>
-			: never
-		: Extract<NonNullable<T[P]>, Record<string, unknown>> extends Record<string, unknown>
-		? Extract<NonNullable<T[P]>, Record<string, unknown>>
-		: never;
+	? Extract<U, Record<string, unknown>> extends Record<string, unknown>
+	? Extract<U, Record<string, unknown>>
+	: never
+	: Extract<NonNullable<T[P]>, Record<string, unknown>> extends Record<string, unknown>
+	? Extract<NonNullable<T[P]>, Record<string, unknown>>
+	: never;
 };
 
 export type SharedAggregate = {
@@ -279,12 +282,8 @@ type Single<T, NT = NonNullable<T>> = NT extends Array<unknown> ? NT[number] : N
  * CRUD at its finest
  */
 export interface IItems<T extends Item> {
-	createOne<Q extends QueryOne<T>>(item: PartialItem<T>, query?: Q, options?: ItemsOptions): Promise<OneItem<T, Q>>;
-	createMany<Q extends QueryOne<T>>(
-		items: PartialItem<T>[],
-		query?: Q,
-		options?: ItemsOptions
-	): Promise<ManyItems<T, Q>>;
+	createOne<Q extends QueryOne<T>>(item: ItemInput<T>, query?: Q, options?: ItemsOptions): Promise<OneItem<T, Q>>;
+	createMany<Q extends QueryOne<T>>(items: ItemInput<T>[], query?: Q, options?: ItemsOptions): Promise<ManyItems<T, Q>>;
 
 	readOne<Q extends QueryOne<T>>(id: ID, query?: Q, options?: ItemsOptions): Promise<OneItem<T, Q>>;
 	readMany<Q extends QueryMany<T>>(ids: ID[], query?: Q, options?: ItemsOptions): Promise<ManyItems<T, Q>>;
@@ -292,13 +291,13 @@ export interface IItems<T extends Item> {
 
 	updateOne<Q extends QueryOne<T>>(
 		id: ID,
-		item: PartialItem<T>,
+		item: ItemInput<T>,
 		query?: Q,
 		options?: ItemsOptions
 	): Promise<OneItem<T, Q>>;
 	updateMany<Q extends QueryMany<T>>(
 		ids: ID[],
-		item: PartialItem<T>,
+		item: ItemInput<T>,
 		query?: Q,
 		options?: ItemsOptions
 	): Promise<ManyItems<T, Q>>;
@@ -317,24 +316,24 @@ type IsUnion<T, U extends T = T> = T extends unknown ? ([U] extends [T] ? false 
 type AppendToPath<Path extends string, Appendix extends string> = Path extends '' ? Appendix : `${Path}.${Appendix}`;
 type OneLevelUp<Path extends string> = Path extends `${infer Start}.${infer Middle}.${infer Rest}`
 	? Rest extends `${string}.${string}.${string}`
-		? `${Start}.${Middle}.${OneLevelUp<Rest>}`
-		: Rest extends `${infer NewMiddle}.${string}`
-		? `${Start}.${Middle}.${NewMiddle}`
-		: Rest extends string
-		? `${Start}.${Middle}`
-		: ''
+	? `${Start}.${Middle}.${OneLevelUp<Rest>}`
+	: Rest extends `${infer NewMiddle}.${string}`
+	? `${Start}.${Middle}.${NewMiddle}`
+	: Rest extends string
+	? `${Start}.${Middle}`
+	: ''
 	: Path extends `${infer Start}.${string}`
 	? Start
 	: '';
 
 type LevelsToAsterisks<Path extends string> = Path extends `${string}.${string}.${infer Rest}`
 	? Rest extends `${string}.${string}.${string}`
-		? `*.*.${LevelsToAsterisks<Rest>}`
-		: Rest extends `${string}.${string}`
-		? `*.*.*.*`
-		: Rest extends string
-		? `*.*.*`
-		: ''
+	? `*.*.${LevelsToAsterisks<Rest>}`
+	: Rest extends `${string}.${string}`
+	? `*.*.*.*`
+	: Rest extends string
+	? `*.*.*`
+	: ''
 	: Path extends `${string}.${string}`
 	? '*.*'
 	: Path extends ''
@@ -346,51 +345,51 @@ type DefaultAppends<
 	Appendix extends string,
 	Nested extends boolean = true,
 	Prepend extends boolean = true
-> =
+	> =
 	| AppendToPath<Path, Appendix>
 	| AppendToPath<LevelsToAsterisks<Path>, Appendix>
 	| (Prepend extends true
-			?
-					| AppendToPath<Path, '*'>
-					| AppendToPath<LevelsToAsterisks<Path>, Appendix>
-					| (OneLevelUp<Path> extends '' ? never : AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>)
-			: never)
+		?
+		| AppendToPath<Path, '*'>
+		| AppendToPath<LevelsToAsterisks<Path>, Appendix>
+		| (OneLevelUp<Path> extends '' ? never : AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>)
+		: never)
 	| (Nested extends true
-			?
-					| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, Appendix>, '*'>
-					| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, '*'>, '*'>
-					| AppendToPath<AppendToPath<Path, Appendix>, '*'>
-					| AppendToPath<AppendToPath<Path, '*'>, '*'>
-					| (OneLevelUp<Path> extends ''
-							? never
-							: AppendToPath<AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>, '*'>)
-			: never);
+		?
+		| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, Appendix>, '*'>
+		| AppendToPath<AppendToPath<LevelsToAsterisks<Path>, '*'>, '*'>
+		| AppendToPath<AppendToPath<Path, Appendix>, '*'>
+		| AppendToPath<AppendToPath<Path, '*'>, '*'>
+		| (OneLevelUp<Path> extends ''
+			? never
+			: AppendToPath<AppendToPath<AppendToPath<OneLevelUp<Path>, '*'>, Appendix>, '*'>)
+		: never);
 
 type DotSeparated<
 	T,
 	N extends number,
 	Level extends number[] = [],
 	Path extends string = ''
-> = Level['length'] extends N
+	> = Level['length'] extends N
 	? Path
 	: T extends (infer U)[]
 	? Extract<U, Record<string, unknown>> extends Record<string, unknown>
-		? DotSeparated<Extract<U, Record<string, unknown>>, N, Level, Path>
-		: Path
+	? DotSeparated<Extract<U, Record<string, unknown>>, N, Level, Path>
+	: Path
 	: Extract<NonNullable<T>, Record<string, unknown>> extends Record<string, unknown>
 	? {
-			[K in keyof T]: K extends string
-				? NonNullable<T[K]> extends (infer U)[]
-					? Extract<U, Record<string, unknown>> extends never
-						? DefaultAppends<Path, K, false>
-						:
-								| DotSeparated<Extract<U, Record<string, unknown>>, N, [...Level, 0], AppendToPath<Path, K>>
-								| DefaultAppends<Path, K>
-					: Extract<T[K], Record<string, unknown>> extends never
-					? DefaultAppends<Path, K, false>
-					:
-							| DotSeparated<Extract<T[K], Record<string, unknown>>, N, [...Level, 0], AppendToPath<Path, K>>
-							| DefaultAppends<Path, K>
-				: never;
-	  }[keyof T]
+		[K in keyof T]: K extends string
+		? NonNullable<T[K]> extends (infer U)[]
+		? Extract<U, Record<string, unknown>> extends never
+		? DefaultAppends<Path, K, false>
+		:
+		| DotSeparated<Extract<U, Record<string, unknown>>, N, [...Level, 0], AppendToPath<Path, K>>
+		| DefaultAppends<Path, K>
+		: Extract<T[K], Record<string, unknown>> extends never
+		? DefaultAppends<Path, K, false>
+		:
+		| DotSeparated<Extract<T[K], Record<string, unknown>>, N, [...Level, 0], AppendToPath<Path, K>>
+		| DefaultAppends<Path, K>
+		: never;
+	}[keyof T]
 	: never;

--- a/src/items.ts
+++ b/src/items.ts
@@ -8,7 +8,11 @@ export type Item = Record<string, any>;
 export type InferQueryType<T extends ManyItems<any> | QueryOne<any>> = 'data' extends keyof T ? T['data'] : T;
 
 type DefaultItem<T extends Record<string, unknown>> = {
-	[K in keyof T]: T[K] extends (infer _)[] ? (string | number)[] : T[K];
+	[K in keyof T]: NonNullable<T[K]> extends (infer U)[]
+		? Extract<NonNullable<U>, Record<string, unknown>> extends never
+			? U[]
+			: (string | number)[]
+		: T[K];
 };
 
 export type OneItem<

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -1,9 +1,9 @@
-import { Item, OneItem, PartialItem, QueryOne } from './items';
+import { Item, OneItem, ItemInput, QueryOne } from './items';
 
 /**
  * CRUD at its finest
  */
 export interface ISingleton<T extends Item> {
 	read<Q extends QueryOne<T>>(query?: Q): Promise<OneItem<T, Q>>;
-	update<Q extends QueryOne<T>>(item: PartialItem<T>, query?: Q): Promise<OneItem<T, Q>>;
+	update<Q extends QueryOne<T>>(item: ItemInput<T>, query?: Q): Promise<OneItem<T, Q>>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,15 +87,15 @@ export type SettingType = SystemType<{
 	public_foreground: string | null;
 	public_note: string | null;
 	storage_asset_presets:
-		| {
-				fit: string;
-				height: number;
-				width: number;
-				quality: number;
-				key: string;
-				withoutEnlargement: boolean;
-		  }[]
-		| null;
+	| {
+		fit: string;
+		height: number;
+		width: number;
+		quality: number;
+		key: string;
+		withoutEnlargement: boolean;
+	}[]
+	| null;
 	storage_asset_transform: 'none' | 'all' | 'presets';
 }>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,15 +87,15 @@ export type SettingType = SystemType<{
 	public_foreground: string | null;
 	public_note: string | null;
 	storage_asset_presets:
-	| {
-		fit: string;
-		height: number;
-		width: number;
-		quality: number;
-		key: string;
-		withoutEnlargement: boolean;
-	}[]
-	| null;
+		| {
+				fit: string;
+				height: number;
+				width: number;
+				quality: number;
+				key: string;
+				withoutEnlargement: boolean;
+		  }[]
+		| null;
 	storage_asset_transform: 'none' | 'all' | 'presets';
 }>;
 


### PR DESCRIPTION
**Opened as a draft due to the potential issue explained at the bottom!**

This PR changes the type behaviour when you don't specify fields. The return type will now equal the specified type, but will change arrays with objects to arrays with strings or numbers as nested relations are never populated but will instead return their respective ID.

### Potential issue

The nested object behaviour will probably cause wrong types to be created for JSON and CSV fields, as they are properly parsed by the SDK to be objects and arrays respectively. Thoughts on how to properly handle this would be much appreciated!