### PR TITLE
fix options.transport usage

### DIFF
--- a/src/base/directus.ts
+++ b/src/base/directus.ts
@@ -32,7 +32,7 @@ export type DirectusStorageOptions = StorageOptions & { mode?: 'LocalStorage' | 
 
 export type DirectusOptions<IAuthHandler extends IAuth = Auth> = {
 	auth?: IAuthHandler | PartialBy<AuthOptions, 'transport' | 'storage'>;
-	transport?: ITransport | TransportOptions;
+	transport?: ITransport | Partial<TransportOptions>;
 	storage?: IStorage | DirectusStorageOptions;
 };
 
@@ -89,6 +89,7 @@ export class Directus<T extends TypeMap, IAuthHandler extends IAuth = Auth> impl
 		else {
 			this._transport = new Transport({
 				url: this.url,
+				...this._options?.transport,
 				beforeRequest: async (config) => {
 					await this._auth.refreshIfExpired();
 					const token = this.storage.auth_token;
@@ -98,15 +99,19 @@ export class Directus<T extends TypeMap, IAuthHandler extends IAuth = Auth> impl
 							: `Bearer ${this.storage.auth_token}`
 						: '';
 
-					return {
+					const authenticatedConfig = {
 						...config,
 						headers: {
 							Authorization: bearer,
 							...config.headers,
 						},
 					};
+
+					if (!(this._options?.transport instanceof ITransport) && this._options?.transport?.beforeRequest) {
+						return this._options?.transport?.beforeRequest(authenticatedConfig);
+					}
+					return authenticatedConfig;
 				},
-				...this._options?.transport,
 			});
 		}
 


### PR DESCRIPTION
- options.transport.url is not required anymore (fallback to default url) 
- options.transport.beforeRequest now benefits the authentication headers, making user not forced to implement full transport class and simply use options.transport.beforeRequest to override the parameters he wants

fixes [issue 79](https://github.com/directus/sdk/issues/79)