### PR TITLE
add a force option to refresh()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/sdk",
-	"version": "10.3.2",
+	"version": "10.3.3",
 	"description": "The official Directus SDK for use in JavaScript!",
 	"repository": "directus/sdk",
 	"main": "dist/sdk.cjs.js",

--- a/src/base/auth.ts
+++ b/src/base/auth.ts
@@ -108,7 +108,7 @@ export class Auth extends IAuth {
 	refresh(force = false): Promise<AuthResult | false> {
 		const refreshPromise = async () => {
 			const refresh_token = this._storage.auth_refresh_token;
-			if (force && !refresh_token) return false;
+			if (!force && !refresh_token) return false;
 
 			this.resetStorage();
 

--- a/src/base/auth.ts
+++ b/src/base/auth.ts
@@ -105,10 +105,10 @@ export class Auth extends IAuth {
 		}
 	}
 
-	refresh(): Promise<AuthResult | false> {
+	refresh(force = false): Promise<AuthResult | false> {
 		const refreshPromise = async () => {
 			const refresh_token = this._storage.auth_refresh_token;
-			if (!refresh_token) return false;
+			if (force && !refresh_token) return false;
 
 			this.resetStorage();
 


### PR DESCRIPTION
Normally you wouldn't manually force a token refresh, but on the off chance you do, this update lets you pass `true` in the `refresh` function to force it to refresh regardless of having a refresh token or not.