### PR TITLE
Remove Axios dependency to be edge runtime compliant

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
 	collectCoverageFrom: ['src/**/*.ts'],
 	testPathIgnorePatterns: ['dist'],
 	testMatch: ['<rootDir>/tests/**/*.test.ts'],
+	setupFilesAfterEnv: ['./jest.setup.js'],
 	testEnvironmentOptions: {
 		url: process.env.TEST_URL || 'http://localhost',
 	},

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+global.fetch = require('fetch-cookie')(require('node-fetch'));

--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
 	],
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"license": "MIT",
-	"dependencies": {
-		"axios": "^0.27.2"
-	},
 	"devDependencies": {
 		"@rollup/plugin-commonjs": "22.0.2",
 		"@rollup/plugin-json": "4.1.0",
@@ -61,10 +58,12 @@
 		"eslint": "^8.19.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-prettier": "^4.2.1",
+		"fetch-cookie": "^2.1.0",
 		"jest": "28.1.3",
 		"jest-environment-jsdom": "28.1.3",
 		"lint-staged": "^13.0.3",
 		"nock": "13.2.9",
+		"node-fetch": "^2.6.7",
 		"npm-run-all": "4.1.5",
 		"prettier": "^2.7.1",
 		"rimraf": "3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,15 +9,16 @@ specifiers:
   '@typescript-eslint/eslint-plugin': ^5.30.5
   '@typescript-eslint/parser': ^5.30.5
   argon2: 0.28.7
-  axios: ^0.27.2
   dotenv: 16.0.1
   eslint: ^8.19.0
   eslint-config-prettier: ^8.5.0
   eslint-plugin-prettier: ^4.2.1
+  fetch-cookie: ^2.1.0
   jest: 28.1.3
   jest-environment-jsdom: 28.1.3
   lint-staged: ^13.0.3
   nock: 13.2.9
+  node-fetch: ^2.6.7
   npm-run-all: 4.1.5
   prettier: ^2.7.1
   rimraf: 3.0.2
@@ -32,9 +33,6 @@ specifiers:
   tslib: ^2.4.0
   typescript: 4.7.4
 
-dependencies:
-  axios: 0.27.2
-
 devDependencies:
   '@rollup/plugin-commonjs': 22.0.2_rollup@2.77.2
   '@rollup/plugin-json': 4.1.0_rollup@2.77.2
@@ -48,10 +46,12 @@ devDependencies:
   eslint: 8.19.0
   eslint-config-prettier: 8.5.0_eslint@8.19.0
   eslint-plugin-prettier: 4.2.1_7uxdfn2xinezdgvmbammh6ev5i
+  fetch-cookie: 2.1.0
   jest: 28.1.3_m5viy4k3z5fvr23x3vt4rf2ffm
   jest-environment-jsdom: 28.1.3
   lint-staged: 13.0.3
   nock: 13.2.9
+  node-fetch: 2.6.7
   npm-run-all: 4.1.5
   prettier: 2.7.1
   rimraf: 3.0.2
@@ -1264,21 +1264,13 @@ packages:
 
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: true
 
   /atob/2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
     engines: {node: '>= 4.5.0'}
     hasBin: true
     dev: true
-
-  /axios/0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-    dependencies:
-      follow-redirects: 1.15.1
-      form-data: 4.0.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
 
   /babel-jest/28.1.3_@babel+core@7.18.6:
     resolution: {integrity: sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==}
@@ -1548,6 +1540,7 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
+    dev: true
 
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1669,6 +1662,7 @@ packages:
   /delayed-stream/1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+    dev: true
 
   /delegates/1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -2061,6 +2055,13 @@ packages:
       bser: 2.1.1
     dev: true
 
+  /fetch-cookie/2.1.0:
+    resolution: {integrity: sha512-39+cZRbWfbibmj22R2Jy6dmTbAWC+oqun1f1FzQaNurkPDUP4C38jpeZbiXCR88RKRVDp8UcDrbFXkNhN+NjYg==}
+    dependencies:
+      set-cookie-parser: 2.6.0
+      tough-cookie: 4.0.0
+    dev: true
+
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2104,16 +2105,6 @@ packages:
     resolution: {integrity: sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==}
     dev: true
 
-  /follow-redirects/1.15.1:
-    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
-
   /form-data/4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
@@ -2121,6 +2112,7 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+    dev: true
 
   /fs-extra/10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -3333,12 +3325,14 @@ packages:
   /mime-db/1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /mime-types/2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+    dev: true
 
   /mimic-fn/2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -3982,6 +3976,10 @@ packages:
 
   /set-blocking/2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+    dev: true
+
+  /set-cookie-parser/2.6.0:
+    resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
     dev: true
 
   /shebang-command/1.2.0:

--- a/src/base/transport.ts
+++ b/src/base/transport.ts
@@ -25,11 +25,13 @@ function serializeSearchParams(obj: object, prefix = '', isArray = false): strin
 		if (obj.hasOwnProperty(p)) {
 			const k = prefix ? `${prefix}[${isArray ? '' : p}]` : p;
 			const v = obj[p as keyof typeof obj];
-			str.push(
-				v !== null && typeof v === 'object'
-					? serializeSearchParams(v, k, Array.isArray(v))
-					: encode(k) + '=' + encode(v)
-			);
+			if (v !== null && Array.isArray(v)) {
+				str.push(serializeSearchParams(v, k, Array.isArray(v)));
+			} else if (v !== null && typeof v === 'object') {
+				str.push(`${encode(k)}=${encodeURIComponent(JSON.stringify(v))}`);
+			} else {
+				str.push(`${encode(k)}=${encode(v)}`);
+			}
 		}
 	}
 	return str.join('&');

--- a/src/base/transport.ts
+++ b/src/base/transport.ts
@@ -1,11 +1,44 @@
-import axios, { AxiosInstance, AxiosError, AxiosRequestConfig } from 'axios';
-import { ITransport, TransportMethods, TransportResponse, TransportError, TransportOptions } from '../transport';
+import {
+	ITransport,
+	TransportMethods,
+	TransportResponse,
+	TransportError,
+	TransportOptions,
+	RequestConfig,
+} from '../transport';
+
+function encode(val: string): string {
+	return encodeURIComponent(val)
+		.replace(/%3A/gi, ':')
+		.replace(/%24/g, '$')
+		.replace(/%2C/gi, ',')
+		.replace(/%20/g, '+')
+		.replace(/%5B/gi, '[')
+		.replace(/%5D/gi, ']');
+}
+
+function serializeSearchParams(obj: object, prefix = '', isArray = false): string {
+	const str = [];
+	let p;
+	for (p in obj) {
+		// eslint-disable-next-line no-prototype-builtins
+		if (obj.hasOwnProperty(p)) {
+			const k = prefix ? `${prefix}[${isArray ? '' : p}]` : p;
+			const v = obj[p as keyof typeof obj];
+			str.push(
+				v !== null && typeof v === 'object'
+					? serializeSearchParams(v, k, Array.isArray(v))
+					: encode(k) + '=' + encode(v)
+			);
+		}
+	}
+	return str.join('&');
+}
 
 /**
  * Transport implementation
  */
 export class Transport extends ITransport {
-	private axios: AxiosInstance;
 	private config: TransportOptions;
 
 	constructor(config: TransportOptions) {
@@ -13,20 +46,16 @@ export class Transport extends ITransport {
 
 		this.config = config;
 
-		this.axios = axios.create({
-			baseURL: this.config.url,
-			params: this.config.params,
-			headers: this.config.headers,
-			onUploadProgress: this.config.onUploadProgress,
-			maxBodyLength: this.config.maxBodyLength,
-			maxContentLength: this.config.maxContentLength,
-			withCredentials: true,
-		});
+		if (this.config.url.endsWith('/')) {
+			this.config.url = this.config.url.slice(0, -1);
+		}
 
-		if (this.config?.beforeRequest) this.beforeRequest = this.config.beforeRequest;
+		if (this.config?.beforeRequest) {
+			this.beforeRequest = this.config.beforeRequest;
+		}
 	}
 
-	async beforeRequest(config: AxiosRequestConfig): Promise<AxiosRequestConfig> {
+	async beforeRequest(config: RequestConfig): Promise<RequestConfig> {
 		return config;
 	}
 
@@ -37,56 +66,94 @@ export class Transport extends ITransport {
 	protected async request<T = any, R = any>(
 		method: TransportMethods,
 		path: string,
-		data?: Record<string, any>,
+		data?: any,
 		options?: Omit<TransportOptions, 'url'>
 	): Promise<TransportResponse<T, R>> {
 		try {
-			let config: AxiosRequestConfig = {
+			let config: RequestConfig = {
 				method,
-				url: path,
-				data: data,
+				url: `${this.config.url}${path}`,
 				params: options?.params,
-				headers: options?.headers,
+				headers: options?.headers || {},
 				responseType: options?.responseType,
 				onUploadProgress: options?.onUploadProgress,
+				credentials: options?.credentials || 'include',
 			};
+
+			if (config.params) {
+				config.url = `${config.url}?${serializeSearchParams(config.params)}`;
+			}
+
+			if (data) {
+				config.body = JSON.stringify(data);
+			}
 
 			config = await this.beforeRequest(config);
 
-			const response = await this.axios.request<any>(config);
+			const response = await fetch(config.url, {
+				method: config.method.toUpperCase(),
+				headers: {
+					'Content-Type': 'application/json',
+					...config.headers,
+				},
+				body: JSON.stringify(data),
+				credentials: config?.credentials,
+			});
+
+			const responseText = await response.text();
+			let isJsonResponse = true;
+			let result = responseText as any;
+			try {
+				result = JSON.parse(responseText);
+			} catch (e) {
+				isJsonResponse = false;
+			}
+
+			if (response.status >= 400) {
+				throw new TransportError<T, R>(null, {
+					raw: result,
+					status: response.status,
+					statusText: response.statusText,
+					headers: response.headers,
+					data: isJsonResponse ? result.data : undefined,
+					meta: isJsonResponse ? result.meta : undefined,
+					errors: isJsonResponse ? result.errors : undefined,
+				});
+			}
+
+			if (!isJsonResponse) {
+				return {
+					raw: result,
+					status: response.status,
+					statusText: response.statusText,
+					headers: response.headers,
+				};
+			}
 
 			const content = {
-				raw: response.data as any,
+				raw: result,
 				status: response.status,
 				statusText: response.statusText,
 				headers: response.headers,
-				data: response.data.data,
-				meta: response.data.meta,
-				errors: response.data.errors,
+				data: result.data,
+				meta: result.meta,
+				errors: result.errors,
 			};
 
-			if (response.data.errors) {
+			if (result.errors && result.errors.length > 0) {
 				throw new TransportError<T, R>(null, content);
 			}
 
 			return content;
 		} catch (err: any) {
-			if (!err || err instanceof Error === false) {
+			if (!err || err instanceof Error === false || err instanceof TransportError) {
 				throw err;
 			}
 
-			if (axios.isAxiosError(err)) {
-				const data = err.response?.data as any;
-
-				throw new TransportError<T>(err as AxiosError, {
-					raw: err.response?.data,
-					status: err.response?.status,
-					statusText: err.response?.statusText,
-					headers: err.response?.headers,
-					data: data?.data,
-					meta: data?.meta,
-					errors: data?.errors,
-				});
+			if (typeof err === 'object' && err.toString().startsWith('FetchError:')) {
+				const message = err.message as string;
+				const reason = message.match(/reason: (.+)$/)?.[1];
+				throw new TransportError<T>(new Error(reason || message));
 			}
 
 			throw new TransportError<T>(err as Error);
@@ -94,30 +161,30 @@ export class Transport extends ITransport {
 	}
 
 	async get<T = any>(path: string, options?: TransportOptions): Promise<TransportResponse<T>> {
-		return await this.request('get', path, undefined, options);
+		return await this.request('GET', path, undefined, options);
 	}
 
 	async head<T = any>(path: string, options?: TransportOptions): Promise<TransportResponse<T>> {
-		return await this.request('head', path, undefined, options);
+		return await this.request('HEAD', path, undefined, options);
 	}
 
 	async options<T = any>(path: string, options?: TransportOptions): Promise<TransportResponse<T>> {
-		return await this.request('options', path, undefined, options);
+		return await this.request('OPTIONS', path, undefined, options);
 	}
 
 	async delete<T = any, D = any>(path: string, data?: D, options?: TransportOptions): Promise<TransportResponse<T>> {
-		return await this.request('delete', path, data, options);
+		return await this.request('DELETE', path, data, options);
 	}
 
 	async put<T = any, D = any>(path: string, data?: D, options?: TransportOptions): Promise<TransportResponse<T>> {
-		return await this.request('put', path, data, options);
+		return await this.request('PUT', path, data, options);
 	}
 
 	async post<T = any, D = any>(path: string, data?: D, options?: TransportOptions): Promise<TransportResponse<T>> {
-		return await this.request('post', path, data, options);
+		return await this.request('POST', path, data, options);
 	}
 
 	async patch<T = any, D = any>(path: string, data?: D, options?: TransportOptions): Promise<TransportResponse<T>> {
-		return await this.request('patch', path, data, options);
+		return await this.request('PATCH', path, data, options);
 	}
 }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,4 +1,3 @@
-import { AxiosRequestConfig, ResponseType } from 'axios';
 import { ItemMetadata } from './items';
 
 export type TransportErrorDescription = {
@@ -18,7 +17,7 @@ export type TransportResponse<T, R = any> = {
 	headers: any;
 };
 
-export type TransportMethods = 'get' | 'delete' | 'head' | 'options' | 'post' | 'put' | 'patch';
+export type TransportMethods = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'UPDATE' | 'DELETE' | 'HEAD' | 'OPTIONS';
 
 export type TransportRequestOptions = {
 	params?: any;
@@ -27,11 +26,12 @@ export type TransportRequestOptions = {
 	onUploadProgress?: ((progressEvent: any) => void) | undefined;
 	maxBodyLength?: number;
 	maxContentLength?: number;
+	credentials?: RequestCredentials;
 };
 
 export type TransportOptions = TransportRequestOptions & {
 	url: string;
-	beforeRequest?: (config: AxiosRequestConfig) => Promise<AxiosRequestConfig>;
+	beforeRequest?: (config: RequestConfig) => Promise<RequestConfig>;
 };
 
 export abstract class ITransport {
@@ -83,3 +83,16 @@ export class TransportError<T = any, R = any> extends Error {
 		Object.setPrototypeOf(this, TransportError.prototype);
 	}
 }
+
+export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
+
+export type RequestConfig = {
+	url: string;
+	method: TransportMethods;
+	params?: Record<string, string>;
+	headers?: Record<string, string>;
+	body?: string;
+	responseType?: ResponseType;
+	credentials?: RequestCredentials;
+	onUploadProgress?: ((progressEvent: any) => void) | undefined;
+};

--- a/tests/handlers/fields.test.ts
+++ b/tests/handlers/fields.test.ts
@@ -22,9 +22,7 @@ describe('fields', function () {
 	});
 
 	test(`check ManyItems return type for readAll`, async (url, nock) => {
-		nock()
-			.get('/fields')
-			.reply(200, { data: [] });
+		nock().get('/fields').reply(200, { data: [] });
 
 		const sdk = new Directus(url);
 		const response = await sdk.fields.readAll();
@@ -33,13 +31,10 @@ describe('fields', function () {
 	});
 
 	test(`check ManyItems return type for readMany`, async (url, nock) => {
-		nock()
-			.get('/fields/posts')
-			.reply(200, { data: [] });
+		nock().get('/fields/posts').reply(200, { data: [] });
 
 		const sdk = new Directus(url);
 		const response = await sdk.fields.readMany('posts');
-		console.log(response);
 
 		expect(Array.isArray(response.data)).toBe(true);
 	});


### PR DESCRIPTION
This PR is the continuation of this PR https://github.com/directus/sdk/pull/103 from @freekrai because I'm not sure if I can just modify that PR.

I removed all dependencies and just use node-fetch and fetch-cookie from devDependencies for the tests.

This PR allows the SDK to run on Edge runtimes, as it uses native fetch.